### PR TITLE
Downgraded Jekyll build version from latest to 3.8.6

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   app:
     volumes:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:latest
+FROM jekyll/jekyll:3.8.6
 COPY Gemfile /srv/jekyll
 RUN bundle install
 CMD jekyll serve --watch --force_polling --verbose --livereload


### PR DESCRIPTION
same issue as described here https://github.com/envygeeks/jekyll-docker/issues/268 4.0.0 seems to have wildly different permissions.

Bumped docker-compose.override.yml dockerfile version to make it build